### PR TITLE
KIRORU_APP_TEAM-165 [メンテ] RecyclerView.AdapterのsetOnClickListenerを呼ぶタイミングについて調査と対応

### DIFF
--- a/app/src/main/java/jp/kiroru/kotlintask02/MainActivity.kt
+++ b/app/src/main/java/jp/kiroru/kotlintask02/MainActivity.kt
@@ -126,7 +126,15 @@ class MyAdapter(private val items: List<Memo>, private val listener: ItemSelecti
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = CellMainBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ViewHolder(binding)
+        return ViewHolder(binding).apply {
+            binding.buttonEdit.setOnClickListener {
+                listener.requireItemEdit(adapterPosition)     // Edit
+            }
+
+            binding.buttonDelete.setOnClickListener {
+                listener.requireItemDelete(adapterPosition)   // Delete
+            }
+        }
     }
 
     override fun getItemCount() = items.size
@@ -140,20 +148,11 @@ class MyAdapter(private val items: List<Memo>, private val listener: ItemSelecti
         holder.tv1.text = textView1
         holder.tv2.text = item.description
 
-        holder.b1.setOnClickListener {
-            listener.requireItemEdit(position)     // Edit
-        }
-
-        holder.b2.setOnClickListener {
-            listener.requireItemDelete(position)   // Delete
-        }
     }
 
     class ViewHolder(cellMainBinding: CellMainBinding):
         RecyclerView.ViewHolder(cellMainBinding.root) {
         val tv1 = cellMainBinding.textView1
         val tv2 = cellMainBinding.textView2
-        val b1 = cellMainBinding.buttonEdit
-        val b2 = cellMainBinding.buttonDelete
     }
 }


### PR DESCRIPTION
### チケット

https://kiroru.backlog.com/view/KIRORU_APP_TEAM-165

### 改修内容

負荷軽減の目的のため、onBindViewHolderに記載しているsetOnClickListenerをonCreateViewHolderで行うよう修正

### チェックリスト

- [x] 編集ボタンをタップすると編集できる画面に遷移すること
- [x]  メモの内容に編集した内容が反映されていること
- [x] 削除ボタンをタップすると削除を確認するダイアログが表示されること
- [x] ダイアログでOKを選択すると選択したメモが削除されること
- [x] リストを1000件程度にしてスクロールしたとき、遅いと感じないこと（違和感がなければ問題ない程度の確認）
- [x] 選択したセルがずれていないこと（削除や追加したときに、選択しているセルにずれが出ていないかの確認）

